### PR TITLE
exec searchd to exit sh process

### DIFF
--- a/searchd.sh
+++ b/searchd.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-searchd -c /etc/sphinxsearch/sphinxy.conf --nodetach "$@"
+exec searchd -c /etc/sphinxsearch/sphinxy.conf --nodetach "$@"
 


### PR DESCRIPTION
By invoking `exec searchd` current shell process is replaced by `searchd` prcoess, thus freeing the mem and making `searchd` be PID 1.
This way `searchd` will receive all messages from system/docker.